### PR TITLE
fixed tests, fixed shapes, fixed svg generation

### DIFF
--- a/examples/test.svg
+++ b/examples/test.svg
@@ -1,5 +1,4 @@
-<svg version="1.1"
-     width="300" height="200"
-     xmlns="http://www.w3.org/2000/svg">
-        <rect width="40%" height="40%" fill="black" />
+<svg version="1.1" width="300" height="200" xmlns="http://www.w3.org/2000/svg">
+    <rect stroke="purple" fill="purple" height="180" width="180" x="60" y="10" />
+    <text fill="black" x="150" y="125" font-size="60" text-anchor="middle">jdf</text>
 </svg>

--- a/index.js
+++ b/index.js
@@ -2,17 +2,12 @@ const { Shape, Square, Circle, Triangle } = require('./lib/shapes');
 const fs = require('fs');
 const inquirer = require('inquirer');
 const color = require('color');
-// const square = new Square('rect', 'black', '40%', '40%');
-
-// const svgData = `<svg version="1.1"
-//      width="300" height="200"
-//      xmlns="http://www.w3.org/2000/svg">
-//         <${square.shape} width="${square.width}" height="${square.height}" fill="${square.fill}" />
-// </svg>`
 
 // fs.writeFile('./examples/test.svg', svgData, (err) => {
 //         err ? console.error(err) : console.log('SVG CREATED!')
 //     })
+
+var svgData = `<svg version="1.1" width="300" height="200" xmlns="http://www.w3.org/2000/svg">\n`
 
 
 const validateColor = function(colorName){
@@ -65,5 +60,21 @@ const questions = [
 
 inquirer
     .prompt(questions)
+    .then((answer) => {
+        if(answer.shape === 'Circle') {
+            var myShape = new Circle('circle', answer.shapeColor);
+        } else if(answer.shape === 'Triangle') {
+            var myShape = new Triangle('polygon', answer.shapeColor);
+        } else if(answer.shape === 'Square') {
+            var myShape = new Square('rect', answer.shapeColor);
+        }
 
+        svgData += `    ${myShape.render()}`;
+        
+        svgData +=  `\n    <text fill="${answer.textColor}" x="150" y="125" font-size="60" text-anchor="middle">${answer.text}</text>\n</svg>`;
+
+        fs.writeFile('./examples/test.svg', svgData, (err) => {
+                    err ? console.error(err) : console.log('SVG CREATED!')
+                });
+    })
 

--- a/lib/shapes.js
+++ b/lib/shapes.js
@@ -1,63 +1,48 @@
 class Shape {
-    constructor(shape, color, height='100%', width='100%') {
+    constructor(shape, color) {
         this.shape = shape;
         this.stroke = color;
-        this.fill = color;
-        this.height = height;
-        this.width = width;
+        this.fill = color;        
     }
 
     render(){
-        if(this.shape === 'rect'){
-            const svgData = `<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <${this.shape} width="${this.width}" height="${this.height}" fill="${this.fill}" />
-            </svg>`
-            return svgData;
-        } else if(this.shape === 'circle'){
-            const svgData = `<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <${this.shape} width="${this.width}" height="${this.height}" fill="${this.fill}" cx="${this.cx}" cy="${this.cy}" r="200" />
-            </svg>`
-            return svgData;
-        } else if(this.shape === 'polygon'){
-            const svgData = `<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <${this.shape} width="${this.width}" height="${this.height}" fill="${this.fill}" points="${this.pointA}, ${this.pointB}, ${this.pointC}" />
-            </svg>`
-            return svgData;
-        } 
-
-        
-
+        var svgData = `<`
+        for (let prop in this){
+            if(prop === 'shape'){
+                svgData += `${this[prop]}`;
+            } else{
+                svgData += ` ${prop}="${this[prop]}"`; 
+            }
+            
+        }
+        svgData += ` />`;
+        return svgData;
     }
 }
 
 class Square extends Shape {
-    constructor(shape, color, height, width, x=10, y=10) {
-        super(shape, color, height, width);
+    constructor(shape, color, x="60", y="10") {
+        super(shape, color);
+        this.height = "180";
+        this.width = "180";
         this.x = x;
         this.y = y;
     }
 }
 
 class Circle extends Shape {
-    constructor(shape, color, height, width, cx=10, cy=10){
-        super(shape, color, height, width);
+    constructor(shape, color, cx="150", cy="100", r=80){
+        super(shape, color);
         this.cx = cx;
         this.cy = cy;
+        this.r = r
     }
 }
 
 class Triangle extends Shape {
-    constructor(shape, color, height, width, pointA="100 10", pointB="300 210", pointC="0 210"){
-        super(shape, color, height, width);
-        this.pointA = pointA;
-        this.pointB = pointB;
-        this.pointC = pointC;
+    constructor(shape, width, height, color, points="150, 18 244, 182 56, 182"){
+        super(shape, width, height, color);
+        this.points = points;
     }
 }
 

--- a/lib/shapes.test.js
+++ b/lib/shapes.test.js
@@ -4,31 +4,19 @@ describe('Shapes', () => {
     describe('rect', () => {
         it('Should output rect object', () => {
             const firstSquare = new Square('rect', 'black');
-            expect(firstSquare.render()).toEqual(`<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <rect width="100%" height="100%" fill="black" />
-            </svg>`);
+            expect(firstSquare.render()).toEqual(`<rect stroke="black" fill="black" height="180" width="180" x="60" y="10" />`);
         })
     })
     describe('Circle', () => {
         it('Should output circle object', () => {
             const firstCircle = new Circle('circle', 'black');
-            expect(firstCircle.render()).toEqual(`<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <circle width="100%" height="100%" fill="black" cx="10" cy="10" r="200" />
-            </svg>`);
+            expect(firstCircle.render()).toEqual(`<circle stroke="black" fill="black" cx="150" cy="100" r="80" />`);
         })
     })
     describe('Polygon', () => {
         it('Should output polygon object', () => {
             const firstTriangle = new Triangle('polygon', 'black');
-            expect(firstTriangle.render()).toEqual(`<svg version="1.1"
-            width="300" height="200"
-            xmlns="http://www.w3.org/2000/svg">
-                <polygon width="100%" height="100%" fill="black" points="100 10, 300 210, 0 210" />
-            </svg>`);
+            expect(firstTriangle.render()).toEqual(`<polygon stroke="black" fill="black" points="150, 18 244, 182 56, 182" />`);
         })
     })
 })


### PR DESCRIPTION
Fixed shape rendering to only include the shape svg text by adding all the base svg to a variable in index.js instead. Changed the test to work with new classes. All shpaes now generate correctly and centered. Text now generates in center and at proper size. SVG generates in examples folder